### PR TITLE
fix: use json instead of geopackage format

### DIFF
--- a/pygadm/__init__.py
+++ b/pygadm/__init__.py
@@ -9,7 +9,7 @@ __author__ = "Pierrick Rambaud"
 __email__ = "pierrick.rambaud49@gmail.com"
 
 __gadm_version__ = "410"  # 4.1
-__gadm_url__ = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/gadm41_{}_{}.json"
+__gadm_url__ = "https://geodata.ucdavis.edu/gadm/gadm4.1/json/gadm41_{}_{}.json"
 __gadm_data__ = Path(__file__).parent / "data" / "gadm_database.parquet"
 
 

--- a/pygadm/__init__.py
+++ b/pygadm/__init__.py
@@ -9,7 +9,7 @@ __author__ = "Pierrick Rambaud"
 __email__ = "pierrick.rambaud49@gmail.com"
 
 __gadm_version__ = "410"  # 4.1
-__gadm_url__ = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/gadm41_{}.gpkg"
+__gadm_url__ = "https://geodata.ucdavis.edu/gadm/gadm4.1/gpkg/gadm41_{}_{}.json"
 __gadm_data__ = Path(__file__).parent / "data" / "gadm_database.parquet"
 
 
@@ -74,8 +74,7 @@ def get_items(
         content_level = max_level
 
     # read the data from server
-    layer_name = f"ADM_ADM_{content_level}"
-    level_gdf = gpd.read_file(__gadm_url__.format(iso_3), layer=layer_name)
+    level_gdf = gpd.read_file(__gadm_url__.format(iso_3, content_level))
     level_gdf.rename(columns={"COUNTRY": "NAME_0"}, inplace=True)
     gdf = level_gdf[level_gdf[column.format(level)] == id]
 

--- a/tests/test_get_items.py
+++ b/tests/test_get_items.py
@@ -32,12 +32,7 @@ def test_non_existing():
 def test_area():
 
     # request an area
-    bounds = [
-        103.60905500000018,
-        1.1663900010000248,
-        104.08580000000006,
-        1.471388000000104,
-    ]
+    bounds = [103.6091, 1.1664, 104.0858, 1.4714]
     gdf = pygadm.get_items(name="Singapore")
     assert gdf.loc[0]["GID_0"] == "SGP"
     assert all([math.isclose(b, t) for b, t in zip(gdf.total_bounds.tolist(), bounds)])


### PR DESCRIPTION
Fix #3 

distant reading is faster and the downloading of sub region as well. The only moment .gpkg and .json are competing is when requesting the smallest level.
