### PR TITLE
update get_name behavior

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,10 +27,10 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "sphinx_copybutton",
-    "jupyter_sphinx",
     "sphinx_autodoc_typehints",
     "sphinx_design",
     "sphinx-favicon",
+    "jupyter_sphinx",
 ]
 templates_path = ["_templates"]
 exclude_patterns = ["**.ipynb_checkpoints"]  # when working in a Jupyter env.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -21,12 +21,8 @@ For exemple to extract the France geometry you can use the following code:
     gdf = pygadm.get_items(name="France")
 
     # display it in a map 
-    data = gdf.__geo_interface__
-    style = {"color": "red", "fillOpacity": .4}
-
     m = Map(basemap=basemaps.Esri.WorldImagery,  zoom=5, center=[46.21, 2.21])
-    m.add(GeoJSON(data=gdf.__geo_interface__, style=style))
-    
+    m.add(GeoJSON(data=gdf.__geo_interface__, style={"color": "red", "fillOpacity": .4}))
 
     m
 
@@ -40,11 +36,8 @@ If you know the code of the area you try to use, you can use the GADM code inste
     gdf = pygadm.get_items(admin="FRA")
 
     # display it in a map 
-    data = gdf.__geo_interface__
-    style = {"color": "red", "fillOpacity": .4}
-
     m = Map(basemap=basemaps.Esri.WorldImagery,  zoom=5, center=[46.21, 2.21])
-    m.add(GeoJSON(data=gdf.__geo_interface__, style=style))
+    m.add(GeoJSON(data=gdf.__geo_interface__, style={"color": "red", "fillOpacity": .4}))
 
     m
 
@@ -61,11 +54,8 @@ One is not bind to only request a country, any level can be accesed using both n
     gdf = pygadm.get_items(name="Corse-du-Sud")
 
     # display it in a map 
-    data = gdf.__geo_interface__
-    style = {"color": "red", "fillOpacity": .4}
-
     m = Map(basemap=basemaps.Esri.WorldImagery, zoom=8, center=[41.86, 8.97])
-    m.add(GeoJSON(data=gdf.__geo_interface__, style=style))
+    m.add(GeoJSON(data=gdf.__geo_interface__, style={"color": "red", "fillOpacity": .4}))
 
     m
 
@@ -123,11 +113,8 @@ Using the :code:`content_level` option, one can require smaller administrative l
     gdf = pygadm.get_items(admin="FRA", content_level=2)
 
     # display it in a map 
-    data = gdf.__geo_interface__
-    style = {"color": "red", "fillOpacity": .4}
-
     m = Map(basemap=basemaps.Esri.WorldImagery,  zoom=5, center=[46.21, 2.21])
-    m.add(GeoJSON(data=gdf.__geo_interface__, style=style))
+    m.add(GeoJSON(data=gdf.__geo_interface__, style={"color": "red", "fillOpacity": .4}))
 
     m
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -69,9 +69,46 @@ One is not bind to only request a country, any level can be accesed using both n
 
     m
 
+Duplication issue
+^^^^^^^^^^^^^^^^^
+
 .. warning::
 
     The names of countries are all unique but not the smaller administrative layers. If you request a small area using name, make sure it's the one you are looking for before running your workflow. If it's not the case, use the :code:`get_names` method to get the administrative code assosciated to the requested names, they are all unique.
+
+Let's demonstrate this behavior with the "Central" province of Singapore. First we try to load it using its name. It should return an error:  
+
+.. jupyter-execute::
+    :raises: ValueError 
+
+    import pygadm
+
+    gdf = pygadm.get_items(name="Central")
+
+As I don't know the GADM code I copy/paste the suggested code from the error message and filter it by `country ISO alpha-3 code <https://www.iban.com/country-codes>`__. the ISO code is always displayed in the second column of the :code:`get_names` output. All GADM code start with the country ISO code so you can use the provided cell for any admin level. 
+
+.. jupyter-execute::
+
+    import pygadm 
+
+    df = pygadm.get_names(name="Central")
+    df = df[df.iloc[:,1].str.startswith("SGP")]
+    df
+
+I now know that the code is "SGP.1_1" for the Central province so I can run my initial code again with the unique :code:`admin` parameter: 
+
+.. jupyter-execute:: 
+
+    import pygadm 
+    from ipyleaflet import GeoJSON, Map, basemaps
+
+    gdf = pygadm.get_items(admin="SGP.1_1")
+
+    # display it in a map 
+    m = Map(basemap=basemaps.Esri.WorldImagery,  zoom=11, center=[1.29, 103.83])
+    m.add(GeoJSON(data=gdf.__geo_interface__, style={"color": "red", "fillOpacity": .4}))
+
+    m 
 
 Content of an admin layer
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/noxfile.py
+++ b/noxfile.py
@@ -7,7 +7,7 @@ def lint(session):
     session.run("pre-commit", "run", "--a", *session.posargs)
 
 
-@nox.session(python=["3.7", "3.8", "3.9"])
+@nox.session(python=["3.7", "3.8", "3.9"], reuse_venv=True)
 def test(session):
     session.install(".[test]")
     session.run("pytest", "--color=yes", "--cov", "--cov-report=html", "tests")

--- a/pygadm/__init__.py
+++ b/pygadm/__init__.py
@@ -90,12 +90,12 @@ def get_names(name: str = "", admin: str = "", content_level: int = -1) -> pd.Da
     """
     Return the list of names available in a administrative layer using the name or the administrative code
 
-    Return a pandas DataFrame of all the name contained in an administrative region. The region can be requested either by its "name" or its "admin", the lib will identify the coresponding level on the fly. The user can also request for a specific level for its content e.g. get all admin level 1 of a country. If nothing is set we will infer the level of the item and if the level is higher than the found item, it will be ignored. If Nothing is found the method will return an error.
+    Return a pandas DataFrame of the names ad GADM code of an administrative region. The region can be requested either by its "name" or its "admin", the lib will identify the coresponding level on the fly. The user can also request for a specific level for its content e.g. get all admin level 1 of a country. If nothing is set we will infer the level of the item and if the level is higher than the found item, it will be ignored. If Nothing is found the method will return an error.
 
     Args:
         name: The name of a administrative area. Cannot be set along with :code:`admin`.
         admin: The id of an administrative area in the GADM nomenclature. Cannot be set along with :code:`name`.
-        content_level: The level to use in the final dataset. Default to -1 (use level under the area).
+        content_level: The level to use in the final dataset. Default to -1 (use level of the selected area).
 
     Returns:
         The list of all the available names.
@@ -133,7 +133,7 @@ def get_names(name: str = "", admin: str = "", content_level: int = -1) -> pd.Da
 
     # get the request level from user
     if content_level == -1:
-        content_level = int(level) + 1
+        content_level = level
     elif content_level < int(level):
         warnings.warn(
             f"The requested level ({content_level}) is higher than the area ({level}). Fallback to {level}."

--- a/pygadm/__init__.py
+++ b/pygadm/__init__.py
@@ -30,52 +30,22 @@ def get_items(
         The GeoDataFrame of the requested area with all the GADM attributes.
     """
 
-    # sanitary check on parameters
-    if name and admin:
-        raise ValueError('"name" and "id" cannot be set at the same time.')
-    elif not name and not admin:
-        raise ValueError('at least "name" or "id" need to be set.')
+    # call to get_names without level to raise an error if the requested level won't work
+    df = get_names(name, admin)
+    if len(df) > 1:
+        raise ValueError(
+            f'The requested name ("{name}") is not unique ({len(df)} results). To retreive it, please use the `admin` parameter instead. If you don\'t know the GADM code, use the following code, it will return the GADM codes as well:\n`get_names(name="{name}")`'
+        )
+    level = df.columns[0].replace("NAME_", "")
+    iso_3 = df.iloc[0][f"GID_{level}"][:3]
 
-    # set the id we look for and tell the function if its a name or an admin
-    is_name = True if name else False
+    # now load the usefull one to get content_level
+    df = get_names(name, admin, content_level)
+    content_level = df.columns[0].replace("NAME_", "")
+
+    # checks have already been performed in get_names
+    column = "NAME_{}" if name else "GID_{}"
     id = name if name else admin
-
-    # read the data and find if the element exist
-    df = pd.read_parquet(__gadm_data__)
-    column = "NAME_{}" if is_name else "GID_{}"
-    is_in = (
-        df.filter([column.format(i) for i in range(6)])
-        .apply(lambda col: col.str.lower())
-        .isin([id.lower()])
-    )
-
-    if not is_in.any().any():
-        raise Exception(f'The requested "{id}" is not part of GADM')
-
-    # Get the iso_3 of the associated country of the identifed area and the associated level
-    line = is_in[~((~is_in).all(axis=1))].idxmax(1)
-    index = line.index
-    level = line.iloc[0][5 if is_name else 4]  # GID_ or NAME_
-    iso_3 = df.loc[index, "GID_0"].array[0]
-
-    # load the max_level available in the requested area
-    sub_df = df[df[column.format(level)].str.fullmatch(id, case=False)]
-    max_level = next(i for i in reversed(range(6)) if (sub_df[f"GID_{i}"] != "").any())
-
-    # get the request level from user
-    if content_level == -1:
-        content_level = level
-    elif content_level < int(level):
-        warnings.warn(
-            f"The requested level ({content_level}) is higher than the area ({level}). Fallback to {level}."
-        )
-        content_level = level
-
-    if int(content_level) > max_level:
-        warnings.warn(
-            f"The requested level ({content_level}) is higher than the max level in this country ({max_level}). Fallback to {max_level}."
-        )
-        content_level = max_level
 
     # read the data from server
     layer_name = f"ADM_ADM_{content_level}"

--- a/tests/test_get_items.py
+++ b/tests/test_get_items.py
@@ -69,3 +69,11 @@ def test_too_low():
         gdf = pygadm.get_items(admin="SGP.1_1", content_level=3)
         assert len(gdf) == 1
         assert gdf.loc[0]["GID_1"] == "SGP.1_1"
+
+
+def test_case_insensitive():
+
+    gdf1 = pygadm.get_items(name="Singapore")
+    gdf2 = pygadm.get_items(name="singaPORE")
+
+    assert gdf1.equals(gdf2)

--- a/tests/test_get_items.py
+++ b/tests/test_get_items.py
@@ -23,10 +23,10 @@ def test_non_existing():
 
     # request non-existing area
     with pytest.raises(Exception):
-        pygadm.get_items(name="toto")
+        pygadm.get_items(name="t0t0")
 
     with pytest.raises(Exception):
-        pygadm.get_items(admin="toto")
+        pygadm.get_items(admin="t0t0")
 
 
 def test_area():

--- a/tests/test_get_names.py
+++ b/tests/test_get_names.py
@@ -21,10 +21,10 @@ def test_nono_existing():
 
     # request non-existing area
     with pytest.raises(Exception):
-        pygadm.get_names(name="toto")
+        pygadm.get_names(name="t0t0")
 
     with pytest.raises(Exception):
-        pygadm.get_names(admin="toto")
+        pygadm.get_names(admin="t0t0")
 
 
 def test_area():

--- a/tests/test_get_names.py
+++ b/tests/test_get_names.py
@@ -60,3 +60,11 @@ def test_too_low():
         df = pygadm.get_names(admin="SGP.1_1", content_level=3)
         assert len(df) == 1
         assert df.NAME_1.to_list() == ["Central"]
+
+
+def test_case_insensitive():
+
+    df1 = pygadm.get_names(name="Singapore")
+    df2 = pygadm.get_names(name="singaPORE")
+
+    assert df1.equals(df2)

--- a/tests/test_get_names.py
+++ b/tests/test_get_names.py
@@ -30,9 +30,9 @@ def test_nono_existing():
 def test_area():
 
     # request an area
-    sublevels = ["Central", "East", "North", "North-East", "West"]
+    sublevels = ["Singapore"]
     df = pygadm.get_names(name="Singapore")
-    assert sorted(df.NAME_1.to_list()) == sublevels
+    assert sorted(df.NAME_0.to_list()) == sublevels
 
 
 def test_sub_content():


### PR DESCRIPTION
Fix #2 

- [x] `get_names` and `get_items` are no case sensitive anymore
- [x] `get_names` provide the same results as `get_items` to be used as debugging method when multiple items are found
- [x] refactor the lib calls to reduce duplicate code 
- [x] call `get_names` in `get_items` to guess errors (multiple line when performing a default search)