### PR TITLE
fix:

### DIFF
--- a/pygadm/__init__.py
+++ b/pygadm/__init__.py
@@ -230,7 +230,12 @@ class Items(gpd.GeoDataFrame):
 
         level_gdf = gpd.GeoDataFrame.from_features(data)
         level_gdf.rename(columns={"COUNTRY": "NAME_0"}, inplace=True)
-        gdf = level_gdf[level_gdf[column.format(level)].str.fullmatch(id, case=False)]
+
+        # as explained in the next comment data from the geojson are completely broken
+        # to make sure the fullmatch works we need to replace the name with full camelcas alternative.
+        # should be removed once the next version of GADM is released.
+        corrected_id = id.title().replace(" ", "")
+        gdf = level_gdf[level_gdf[column.format(level)].str.fullmatch(corrected_id, case=False)]
 
         # workaround for the wrong naming convention in the geojson files
         # https://gis.stackexchange.com/questions/467848/how-to-get-back-spaces-in-administrative-names-in-gadm-4-1

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -48,6 +48,12 @@ def test_too_high(data_regression):
         data_regression.check(gdf.GID_1.tolist())
 
 
+def test_multi_word_name(dataframe_regression):
+    """Request a multi-word area."""
+    gdf = pygadm.Items(name="United States")
+    dataframe_regression.check(gdf[["NAME_0", "GID_0"]])
+
+
 def test_too_low(data_regression):
     """Request a sublevel lower than available in the area."""
     # request a level too low

--- a/tests/test_items/test_multi_word_name.csv
+++ b/tests/test_items/test_multi_word_name.csv
@@ -1,0 +1,2 @@
+,NAME_0,GID_0
+0,United States,USA


### PR DESCRIPTION
Due to the geojson bug, names need to be camelcase before being compared to the `fullmatch` function. reason why all the names composed of multiple words were not working. 

I created a test as well as this issue should require some modification upon next GADM release.